### PR TITLE
Fix image style typo in blog landing

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -39,7 +39,7 @@ const Landing = ({ data, switchTheme }) => {
                               alt={edge.node.frontmatter.title}
                               style={{
                                 margin: 'auto',
-                                heigth: '100%',
+                                height: '100%',
                                 width: '100%',
                                 maxHeight: '80%',
                                 maxWidth: '80%',


### PR DESCRIPTION
## Summary
- fix typo `heigth` -> `height` on index landing page

## Testing
- `npm test` *(fails: Write tests! -> https://gatsby.dev/unit-testing)*

------
https://chatgpt.com/codex/tasks/task_e_6841a30048c4832f9b157ba30d11a20c