### PR TITLE
Refactor Topbar sticky logic into hook

### DIFF
--- a/src/components/Topbar/index.jsx
+++ b/src/components/Topbar/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { Row, Col } from 'react-flexbox-grid'
 import Toggle from 'react-toggle'
 import { useTheme, Text, Link } from '@geist-ui/react'
@@ -15,31 +15,12 @@ import {
 } from './style'
 import paths from '../../utils/paths'
 import './style.css'
+import useStickyNavInMainPage from '../../hooks/useStickyNavInMainPage'
 
 const Topbar = ({ switchTheme, isMainPage }) => {
   const theme = useTheme()
 
-  useEffect(() => {
-    const navbar = document.getElementById('navbar')
-    const sticky = navbar.offsetTop
-    const height = navbar.offsetHeight
-
-    const addStickyToNavBar = () => {
-      if (
-        window.pageYOffset >= sticky + navbar.offsetHeight - height ||
-        !isMainPage
-      ) {
-        navbar.classList.add('sticky')
-      } else {
-        navbar.classList.remove('sticky')
-      }
-    }
-    addStickyToNavBar()
-
-    window.onscroll = function () {
-      addStickyToNavBar()
-    }
-  })
+  useStickyNavInMainPage(isMainPage)
 
   return (
     <>

--- a/src/hooks/useStickyNavInMainPage.js
+++ b/src/hooks/useStickyNavInMainPage.js
@@ -1,0 +1,27 @@
+import { useEffect } from 'react'
+
+const useStickyNavInMainPage = (isMainPage) => {
+  useEffect(() => {
+    const navbar = document.getElementById('navbar')
+    const sticky = navbar.offsetTop
+    const height = navbar.offsetHeight
+
+    const addStickyToNavBar = () => {
+      if (
+        window.pageYOffset >= sticky + navbar.offsetHeight - height ||
+        !isMainPage
+      ) {
+        navbar.classList.add('sticky')
+      } else {
+        navbar.classList.remove('sticky')
+      }
+    }
+    addStickyToNavBar()
+
+    window.onscroll = function () {
+      addStickyToNavBar()
+    }
+  })
+}
+
+export default useStickyNavInMainPage


### PR DESCRIPTION
## Summary
- move sticky navbar effect into `useStickyNavInMainPage`
- use the custom hook in `Topbar`

## Testing
- `npm test` *(fails: Write tests! -> https://gatsby.dev/unit-testing)*

------
https://chatgpt.com/codex/tasks/task_e_6841baa31600832f9b549c5d7022de2c