### PR TITLE
Add SEO metadata to blog

### DIFF
--- a/src/pages/__tests__/contact.test.jsx
+++ b/src/pages/__tests__/contact.test.jsx
@@ -11,6 +11,14 @@ jest.mock('react-flexbox-grid', () => {
   return { Grid, Row, Col }
 })
 
+// Mock third-party analytics components used in the page
+jest.mock('@vercel/speed-insights/react', () => ({
+  SpeedInsights: () => null,
+}))
+jest.mock('@vercel/analytics/react', () => ({
+  Analytics: () => null,
+}))
+
 // Mock layout HOC to avoid importing styles and provider logic
 jest.mock('../../components/Layout', () => (Component) => Component)
 

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { graphql, useStaticQuery } from 'gatsby'
+import { graphql } from 'gatsby'
 import { Text, Link, Card, Tag } from '@geist-ui/react'
 import { Grid, Col, Row } from 'react-flexbox-grid'
 import uniqueId from 'lodash/uniqueId'
@@ -16,16 +16,7 @@ const Landing = ({ data, switchTheme }) => {
     site: {
       siteMetadata: { title, description },
     },
-  } = useStaticQuery(graphql`
-    query LandingSiteMeta {
-      site {
-        siteMetadata {
-          title
-          description
-        }
-      }
-    }
-  `)
+  } = data
 
   return (
     <Grid fluid>
@@ -113,6 +104,12 @@ export const query = graphql`
             image
           }
         }
+      }
+    }
+    site {
+      siteMetadata {
+        title
+        description
       }
     }
   }

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { graphql } from 'gatsby'
+import { graphql, useStaticQuery } from 'gatsby'
 import { Text, Link, Card, Tag } from '@geist-ui/react'
 import { Grid, Col, Row } from 'react-flexbox-grid'
 import uniqueId from 'lodash/uniqueId'
@@ -12,10 +12,27 @@ import { Analytics } from '@vercel/analytics/react'
 
 const Landing = ({ data, switchTheme }) => {
   const { edges } = data.allMdx
+  const {
+    site: {
+      siteMetadata: { title, description },
+    },
+  } = useStaticQuery(graphql`
+    query LandingSiteMeta {
+      site {
+        siteMetadata {
+          title
+          description
+        }
+      }
+    }
+  `)
 
   return (
     <Grid fluid>
-      <Helmet title="Tim Givois" defer={false} />
+      <Helmet defer={false}>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+      </Helmet>
       <Topbar isMainPage switchTheme={switchTheme} />
       <SpeedInsights />
       <Analytics />

--- a/src/templates/blogPost.js
+++ b/src/templates/blogPost.js
@@ -127,7 +127,7 @@ const Template = ({ data, switchTheme, theme }) => {
 }
 
 export const pageQuery = graphql`
-  query ($path: String!) {
+  query BlogPostByPath($path: String!) {
     mdx(frontmatter: { path: { eq: $path } }) {
       body
       frontmatter {

--- a/src/templates/blogPost.js
+++ b/src/templates/blogPost.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Row, Col, Grid } from 'react-flexbox-grid'
-import { graphql } from 'gatsby'
+import { graphql, useStaticQuery } from 'gatsby'
 import { Text, Link, useTheme, Code, Display } from '@geist-ui/react'
 import { Helmet } from 'react-helmet'
 import { MDXRenderer } from 'gatsby-plugin-mdx'
@@ -16,9 +16,29 @@ const Template = ({ data, switchTheme, theme }) => {
   const { mdx } = data // data.mdx holds your post data
   const { frontmatter, body } = mdx
   const { palette } = useTheme()
+  const {
+    site: {
+      siteMetadata: { siteUrl },
+    },
+  } = useStaticQuery(graphql`
+    query TemplateSiteMeta {
+      site {
+        siteMetadata {
+          siteUrl
+        }
+      }
+    }
+  `)
   return (
     <Grid fluid style={{ paddingTop: '70px' }}>
-      <Helmet title={frontmatter.title} defer={false} />
+      <Helmet defer={false}>
+        <title>{frontmatter.title}</title>
+        <meta name="description" content={frontmatter.excerpt} />
+        <meta property="og:title" content={frontmatter.title} />
+        <meta property="og:description" content={frontmatter.excerpt} />
+        <meta property="og:image" content={`${siteUrl}${frontmatter.image}`} />
+        <link rel="canonical" href={`${siteUrl}${frontmatter.path}`} />
+      </Helmet>
       <Topbar switchTheme={switchTheme} />
       <Row center="xs">
         <Col xs={11} lg={10}>

--- a/src/templates/blogPost.js
+++ b/src/templates/blogPost.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Row, Col, Grid } from 'react-flexbox-grid'
-import { graphql, useStaticQuery } from 'gatsby'
+import { graphql } from 'gatsby'
 import { Text, Link, useTheme, Code, Display } from '@geist-ui/react'
 import { Helmet } from 'react-helmet'
 import { MDXRenderer } from 'gatsby-plugin-mdx'
@@ -16,19 +16,7 @@ const Template = ({ data, switchTheme, theme }) => {
   const { mdx } = data // data.mdx holds your post data
   const { frontmatter, body } = mdx
   const { palette } = useTheme()
-  const {
-    site: {
-      siteMetadata: { siteUrl },
-    },
-  } = useStaticQuery(graphql`
-    query TemplateSiteMeta {
-      site {
-        siteMetadata {
-          siteUrl
-        }
-      }
-    }
-  `)
+  const siteUrl = 'https://timgivois.me'
   return (
     <Grid fluid style={{ paddingTop: '70px' }}>
       <Helmet defer={false}>


### PR DESCRIPTION
## Summary
- include site metadata on index page
- include per-post metadata on blog pages
- mock analytics components in contact page tests

## Testing
- `yarn format`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68472f88134c832fb4c2a36c30b150e7