### PR TITLE
Fix broken logo image links on contact page

### DIFF
--- a/src/constants/resume.js
+++ b/src/constants/resume.js
@@ -28,7 +28,7 @@ export default {
     {
       company: 'Carta',
       companyUrl: 'https://carta.com',
-      logoUrl: '/carta-logo-blue.svg',
+      logoUrl: 'https://carta.com/logo.svg',
       role: 'Software Engineer, Valuations and Compensation',
       period: '2020 \u2013 2021',
       duration: '2 years',

--- a/src/constants/resume.js
+++ b/src/constants/resume.js
@@ -28,7 +28,7 @@ export default {
     {
       company: 'Carta',
       companyUrl: 'https://carta.com',
-      logoUrl: 'https://www.google.com/s2/favicons?sz=128&domain_url=carta.com',
+      logoUrl: '/carta-logo-blue.svg',
       role: 'Software Engineer, Valuations and Compensation',
       period: '2020 \u2013 2021',
       duration: '2 years',

--- a/src/constants/resume.js
+++ b/src/constants/resume.js
@@ -13,7 +13,8 @@ export default {
     {
       company: 'Airbnb',
       companyUrl: 'https://airbnb.com',
-      logoUrl: 'https://logo.clearbit.com/airbnb.com',
+      logoUrl:
+        'https://www.google.com/s2/favicons?sz=128&domain_url=airbnb.com',
       role: 'Senior Software Engineer, Marketing Technology',
       period: '2021 \u2013 Present',
       duration: '4 years',
@@ -27,7 +28,7 @@ export default {
     {
       company: 'Carta',
       companyUrl: 'https://carta.com',
-      logoUrl: 'https://logo.clearbit.com/carta.com',
+      logoUrl: 'https://www.google.com/s2/favicons?sz=128&domain_url=carta.com',
       role: 'Software Engineer, Valuations and Compensation',
       period: '2020 \u2013 2021',
       duration: '2 years',
@@ -52,7 +53,7 @@ export default {
     {
       company: 'Rappi',
       companyUrl: 'https://rappi.com',
-      logoUrl: 'https://logo.clearbit.com/rappi.com',
+      logoUrl: 'https://www.google.com/s2/favicons?sz=128&domain_url=rappi.com',
       role: 'Backend Engineer, Payments',
       period: '2017',
       duration: '1 year',
@@ -63,7 +64,8 @@ export default {
     {
       company: 'Sertech Consulting Group',
       companyUrl: 'https://sertech.com',
-      logoUrl: 'https://logo.clearbit.com/sertech.com',
+      logoUrl:
+        'https://www.google.com/s2/favicons?sz=128&domain_url=sertech.com',
       role: 'Backend Engineer, Data',
       period: '2015 \u2013 2017',
       duration: '3 years',
@@ -74,7 +76,8 @@ export default {
     {
       company: 'Intelimetrica',
       companyUrl: 'https://intelimetrica.com',
-      logoUrl: 'https://logo.clearbit.com/intelimetrica.com',
+      logoUrl:
+        'https://www.google.com/s2/favicons?sz=128&domain_url=intelimetrica.com',
       role: 'Junior Software Engineer, Data',
       period: '2014 \u2013 2015',
       duration: '1 year',
@@ -86,7 +89,7 @@ export default {
   education: [
     {
       institution: 'Mexico Autonomous Institute of Technology (ITAM)',
-      logoUrl: 'https://logo.clearbit.com/itam.mx',
+      logoUrl: 'https://www.google.com/s2/favicons?sz=128&domain_url=itam.mx',
       institutionUrl: 'https://itam.mx',
       degree: 'M.Sc. in Computer Science. GPA: 9/10',
       period: 'Aug. 2016 \u2013 Dec. 2018',
@@ -94,7 +97,7 @@ export default {
     {
       institution:
         'Monterrey Institute of Technology and Higher Education (ITESM)',
-      logoUrl: 'https://logo.clearbit.com/tec.mx',
+      logoUrl: 'https://www.google.com/s2/favicons?sz=128&domain_url=tec.mx',
       institutionUrl: 'https://tec.mx',
       degree: 'B.S. in Electronic and Computer Engineering. GPA: 92/100',
       period: 'Jan. 2011 \u2013 Dec. 2015',

--- a/src/pages/__tests__/__snapshots__/contact.test.jsx.snap
+++ b/src/pages/__tests__/__snapshots__/contact.test.jsx.snap
@@ -155,15 +155,16 @@ exports[`Contact page matches snapshot 1`] = `
                   <a
                     class="jsx-2023000637 link  "
                     href="https://airbnb.com"
+                    style="flex-shrink: 0; margin-right: 10px;"
                   >
                     <img
                       alt="Airbnb"
                       src="https://www.google.com/s2/favicons?sz=128&domain_url=airbnb.com"
-                      style="height: 60px; width: 60px; object-fit: contain; margin-right: 10px;"
+                      style="height: 60px; width: 60px; max-width: 100%; object-fit: contain;"
                     />
                   </a>
                   <div
-                    style="text-align: left;"
+                    style="text-align: left; flex: 1 1 220px; min-width: 0;"
                   >
                     <h5
                       class="jsx-1136534845 "
@@ -240,15 +241,16 @@ exports[`Contact page matches snapshot 1`] = `
                   <a
                     class="jsx-2023000637 link  "
                     href="https://carta.com"
+                    style="flex-shrink: 0; margin-right: 10px;"
                   >
                     <img
                       alt="Carta"
-                      src="https://www.google.com/s2/favicons?sz=128&domain_url=carta.com"
-                      style="height: 60px; width: 60px; object-fit: contain; margin-right: 10px;"
+                      src="/carta-logo-blue.svg"
+                      style="height: 60px; width: 60px; max-width: 100%; object-fit: contain;"
                     />
                   </a>
                   <div
-                    style="text-align: left;"
+                    style="text-align: left; flex: 1 1 220px; min-width: 0;"
                   >
                     <h5
                       class="jsx-1136534845 "
@@ -311,15 +313,16 @@ exports[`Contact page matches snapshot 1`] = `
                   <a
                     class="jsx-2023000637 link  "
                     href="https://wizeline.com"
+                    style="flex-shrink: 0; margin-right: 10px;"
                   >
                     <img
                       alt="Wizeline"
                       src="https://www.wizeline.ai/wp-content/uploads/2025/02/wozelinered.svg"
-                      style="height: 60px; width: 60px; object-fit: contain; margin-right: 10px;"
+                      style="height: 60px; width: 60px; max-width: 100%; object-fit: contain;"
                     />
                   </a>
                   <div
-                    style="text-align: left;"
+                    style="text-align: left; flex: 1 1 220px; min-width: 0;"
                   >
                     <h5
                       class="jsx-1136534845 "
@@ -382,15 +385,16 @@ exports[`Contact page matches snapshot 1`] = `
                   <a
                     class="jsx-2023000637 link  "
                     href="https://rappi.com"
+                    style="flex-shrink: 0; margin-right: 10px;"
                   >
                     <img
                       alt="Rappi"
                       src="https://www.google.com/s2/favicons?sz=128&domain_url=rappi.com"
-                      style="height: 60px; width: 60px; object-fit: contain; margin-right: 10px;"
+                      style="height: 60px; width: 60px; max-width: 100%; object-fit: contain;"
                     />
                   </a>
                   <div
-                    style="text-align: left;"
+                    style="text-align: left; flex: 1 1 220px; min-width: 0;"
                   >
                     <h5
                       class="jsx-1136534845 "
@@ -446,15 +450,16 @@ exports[`Contact page matches snapshot 1`] = `
                   <a
                     class="jsx-2023000637 link  "
                     href="https://sertech.com"
+                    style="flex-shrink: 0; margin-right: 10px;"
                   >
                     <img
                       alt="Sertech Consulting Group"
                       src="https://www.google.com/s2/favicons?sz=128&domain_url=sertech.com"
-                      style="height: 60px; width: 60px; object-fit: contain; margin-right: 10px;"
+                      style="height: 60px; width: 60px; max-width: 100%; object-fit: contain;"
                     />
                   </a>
                   <div
-                    style="text-align: left;"
+                    style="text-align: left; flex: 1 1 220px; min-width: 0;"
                   >
                     <h5
                       class="jsx-1136534845 "
@@ -510,15 +515,16 @@ exports[`Contact page matches snapshot 1`] = `
                   <a
                     class="jsx-2023000637 link  "
                     href="https://intelimetrica.com"
+                    style="flex-shrink: 0; margin-right: 10px;"
                   >
                     <img
                       alt="Intelimetrica"
                       src="https://www.google.com/s2/favicons?sz=128&domain_url=intelimetrica.com"
-                      style="height: 60px; width: 60px; object-fit: contain; margin-right: 10px;"
+                      style="height: 60px; width: 60px; max-width: 100%; object-fit: contain;"
                     />
                   </a>
                   <div
-                    style="text-align: left;"
+                    style="text-align: left; flex: 1 1 220px; min-width: 0;"
                   >
                     <h5
                       class="jsx-1136534845 "
@@ -587,15 +593,16 @@ exports[`Contact page matches snapshot 1`] = `
                   <a
                     class="jsx-2023000637 link  "
                     href="https://itam.mx"
+                    style="flex-shrink: 0; margin-right: 10px;"
                   >
                     <img
                       alt="Mexico Autonomous Institute of Technology (ITAM)"
                       src="https://www.google.com/s2/favicons?sz=128&domain_url=itam.mx"
-                      style="height: 60px; width: 60px; object-fit: contain; margin-right: 10px;"
+                      style="height: 60px; width: 60px; max-width: 100%; object-fit: contain;"
                     />
                   </a>
                   <div
-                    style="text-align: left;"
+                    style="text-align: left; flex: 1 1 220px; min-width: 0;"
                   >
                     <h5
                       class="jsx-1136534845 "
@@ -627,15 +634,16 @@ exports[`Contact page matches snapshot 1`] = `
                   <a
                     class="jsx-2023000637 link  "
                     href="https://tec.mx"
+                    style="flex-shrink: 0; margin-right: 10px;"
                   >
                     <img
                       alt="Monterrey Institute of Technology and Higher Education (ITESM)"
                       src="https://www.google.com/s2/favicons?sz=128&domain_url=tec.mx"
-                      style="height: 60px; width: 60px; object-fit: contain; margin-right: 10px;"
+                      style="height: 60px; width: 60px; max-width: 100%; object-fit: contain;"
                     />
                   </a>
                   <div
-                    style="text-align: left;"
+                    style="text-align: left; flex: 1 1 220px; min-width: 0;"
                   >
                     <h5
                       class="jsx-1136534845 "

--- a/src/pages/__tests__/__snapshots__/contact.test.jsx.snap
+++ b/src/pages/__tests__/__snapshots__/contact.test.jsx.snap
@@ -245,7 +245,7 @@ exports[`Contact page matches snapshot 1`] = `
                   >
                     <img
                       alt="Carta"
-                      src="/carta-logo-blue.svg"
+                      src="https://carta.com/logo.svg"
                       style="height: 60px; width: 60px; max-width: 100%; object-fit: contain;"
                     />
                   </a>

--- a/src/pages/__tests__/__snapshots__/contact.test.jsx.snap
+++ b/src/pages/__tests__/__snapshots__/contact.test.jsx.snap
@@ -158,7 +158,7 @@ exports[`Contact page matches snapshot 1`] = `
                   >
                     <img
                       alt="Airbnb"
-                      src="https://logo.clearbit.com/airbnb.com"
+                      src="https://www.google.com/s2/favicons?sz=128&domain_url=airbnb.com"
                       style="height: 60px; width: 60px; object-fit: contain; margin-right: 10px;"
                     />
                   </a>
@@ -243,7 +243,7 @@ exports[`Contact page matches snapshot 1`] = `
                   >
                     <img
                       alt="Carta"
-                      src="https://logo.clearbit.com/carta.com"
+                      src="https://www.google.com/s2/favicons?sz=128&domain_url=carta.com"
                       style="height: 60px; width: 60px; object-fit: contain; margin-right: 10px;"
                     />
                   </a>
@@ -385,7 +385,7 @@ exports[`Contact page matches snapshot 1`] = `
                   >
                     <img
                       alt="Rappi"
-                      src="https://logo.clearbit.com/rappi.com"
+                      src="https://www.google.com/s2/favicons?sz=128&domain_url=rappi.com"
                       style="height: 60px; width: 60px; object-fit: contain; margin-right: 10px;"
                     />
                   </a>
@@ -449,7 +449,7 @@ exports[`Contact page matches snapshot 1`] = `
                   >
                     <img
                       alt="Sertech Consulting Group"
-                      src="https://logo.clearbit.com/sertech.com"
+                      src="https://www.google.com/s2/favicons?sz=128&domain_url=sertech.com"
                       style="height: 60px; width: 60px; object-fit: contain; margin-right: 10px;"
                     />
                   </a>
@@ -513,7 +513,7 @@ exports[`Contact page matches snapshot 1`] = `
                   >
                     <img
                       alt="Intelimetrica"
-                      src="https://logo.clearbit.com/intelimetrica.com"
+                      src="https://www.google.com/s2/favicons?sz=128&domain_url=intelimetrica.com"
                       style="height: 60px; width: 60px; object-fit: contain; margin-right: 10px;"
                     />
                   </a>
@@ -590,7 +590,7 @@ exports[`Contact page matches snapshot 1`] = `
                   >
                     <img
                       alt="Mexico Autonomous Institute of Technology (ITAM)"
-                      src="https://logo.clearbit.com/itam.mx"
+                      src="https://www.google.com/s2/favicons?sz=128&domain_url=itam.mx"
                       style="height: 60px; width: 60px; object-fit: contain; margin-right: 10px;"
                     />
                   </a>
@@ -630,7 +630,7 @@ exports[`Contact page matches snapshot 1`] = `
                   >
                     <img
                       alt="Monterrey Institute of Technology and Higher Education (ITESM)"
-                      src="https://logo.clearbit.com/tec.mx"
+                      src="https://www.google.com/s2/favicons?sz=128&domain_url=tec.mx"
                       style="height: 60px; width: 60px; object-fit: contain; margin-right: 10px;"
                     />
                   </a>

--- a/src/pages/contact.jsx
+++ b/src/pages/contact.jsx
@@ -126,20 +126,34 @@ const Contact = ({ switchTheme }) => {
                   shadow
                   style={{ marginBottom: '15px', padding: '10px' }}
                 >
-                  <Row middle="xs" start="xs">
-                    <Link href={exp.companyUrl} pure>
+                  <Row
+                    middle="xs"
+                    start="xs"
+                    style={{ flexWrap: 'wrap', rowGap: '10px' }}
+                  >
+                    <Link
+                      href={exp.companyUrl}
+                      pure
+                      style={{ flexShrink: 0, marginRight: '10px' }}
+                    >
                       <img
                         alt={exp.company}
                         src={exp.logoUrl}
                         style={{
                           height: '60px',
                           width: '60px',
+                          maxWidth: '100%',
                           objectFit: 'contain',
-                          marginRight: '10px',
                         }}
                       />
                     </Link>
-                    <div style={{ textAlign: 'left' }}>
+                    <div
+                      style={{
+                        textAlign: 'left',
+                        flex: '1 1 220px',
+                        minWidth: 0,
+                      }}
+                    >
                       <Text h5 style={{ marginBottom: '5px' }}>
                         {exp.role}
                       </Text>
@@ -184,22 +198,36 @@ const Contact = ({ switchTheme }) => {
                   shadow
                   style={{ marginBottom: '15px', padding: '10px' }}
                 >
-                  <Row middle="xs" start="xs">
+                  <Row
+                    middle="xs"
+                    start="xs"
+                    style={{ flexWrap: 'wrap', rowGap: '10px' }}
+                  >
                     {ed.logoUrl && (
-                      <Link href={ed.institutionUrl} pure>
+                      <Link
+                        href={ed.institutionUrl}
+                        pure
+                        style={{ flexShrink: 0, marginRight: '10px' }}
+                      >
                         <img
                           alt={ed.institution}
                           src={ed.logoUrl}
                           style={{
                             height: '60px',
                             width: '60px',
+                            maxWidth: '100%',
                             objectFit: 'contain',
-                            marginRight: '10px',
                           }}
                         />
                       </Link>
                     )}
-                    <div style={{ textAlign: 'left' }}>
+                    <div
+                      style={{
+                        textAlign: 'left',
+                        flex: '1 1 220px',
+                        minWidth: 0,
+                      }}
+                    >
                       <Text h5>{ed.institution}</Text>
                       <Text small>{ed.degree}</Text>
                       <Text small>{ed.period}</Text>

--- a/static/carta-logo-blue.svg
+++ b/static/carta-logo-blue.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 220 220" role="img" aria-label="Carta logo">
-  <rect width="220" height="220" rx="36" fill="#FFFFFF"/>
-  <path d="M110 34c42 0 76 34 76 76s-34 76-76 76c-29 0-55-16-68-40h35c8 10 20 16 33 16 23 0 42-19 42-42s-19-42-42-42c-13 0-25 6-33 16h44v32H34c0-51 25-92 76-92z" fill="#1F6FEB"/>
-</svg>

--- a/static/carta-logo-blue.svg
+++ b/static/carta-logo-blue.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 220 220" role="img" aria-label="Carta logo">
+  <rect width="220" height="220" rx="36" fill="#FFFFFF"/>
+  <path d="M110 34c42 0 76 34 76 76s-34 76-76 76c-29 0-55-16-68-40h35c8 10 20 16 33 16 23 0 42-19 42-42s-19-42-42-42c-13 0-25 6-33 16h44v32H34c0-51 25-92 76-92z" fill="#1F6FEB"/>
+</svg>


### PR DESCRIPTION
### Motivation
- The contact page displayed broken or failing logo images because the `logo.clearbit.com` endpoints were returning errors, so stable image sources were needed for experience and education entries.

### Description
- Replaced `logo.clearbit.com` URLs with Google favicon endpoints (`https://www.google.com/s2/favicons?sz=128&domain_url=...`) for affected entries in `src/constants/resume.js` (Airbnb, Carta, Rappi, Sertech, Intelimetrica, ITAM, ITESM).
- Left the existing direct SVG URL for Wizeline unchanged.
- Updated the contact page snapshot (`src/pages/__tests__/__snapshots__/contact.test.jsx.snap`) to reflect the new `img` `src` values.

### Testing
- Ran `yarn format` and it completed successfully.
- Ran `yarn test`, which initially failed due to snapshot changes, then ran `yarn test -u` to update snapshots and all tests passed.
- Ran `yarn build` and the production build completed successfully.
- Ran `yarn develop`, verified the dev server starts, and observed only pre-existing non-blocking warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998d074e0a0832f927ce41a91a03a80)