### PR TITLE
Improve contact logo visibility and responsive layout (Carta + Sertech)

### DIFF
--- a/src/constants/resume.js
+++ b/src/constants/resume.js
@@ -13,7 +13,8 @@ export default {
     {
       company: 'Airbnb',
       companyUrl: 'https://airbnb.com',
-      logoUrl: 'https://logo.clearbit.com/airbnb.com',
+      logoUrl:
+        'https://www.google.com/s2/favicons?sz=128&domain_url=airbnb.com',
       role: 'Senior Software Engineer, Marketing Technology',
       period: '2021 \u2013 Present',
       duration: '4 years',
@@ -27,7 +28,7 @@ export default {
     {
       company: 'Carta',
       companyUrl: 'https://carta.com',
-      logoUrl: 'https://logo.clearbit.com/carta.com',
+      logoUrl: '/carta-logo-blue.svg',
       role: 'Software Engineer, Valuations and Compensation',
       period: '2020 \u2013 2021',
       duration: '2 years',
@@ -52,7 +53,7 @@ export default {
     {
       company: 'Rappi',
       companyUrl: 'https://rappi.com',
-      logoUrl: 'https://logo.clearbit.com/rappi.com',
+      logoUrl: 'https://www.google.com/s2/favicons?sz=128&domain_url=rappi.com',
       role: 'Backend Engineer, Payments',
       period: '2017',
       duration: '1 year',
@@ -63,7 +64,8 @@ export default {
     {
       company: 'Sertech Consulting Group',
       companyUrl: 'https://sertech.com',
-      logoUrl: 'https://logo.clearbit.com/sertech.com',
+      logoUrl:
+        'https://sertech.mx/wp-content/themes/sertech/assets/assets_home/img/logo_header.png',
       role: 'Backend Engineer, Data',
       period: '2015 \u2013 2017',
       duration: '3 years',
@@ -74,7 +76,8 @@ export default {
     {
       company: 'Intelimetrica',
       companyUrl: 'https://intelimetrica.com',
-      logoUrl: 'https://logo.clearbit.com/intelimetrica.com',
+      logoUrl:
+        'https://www.google.com/s2/favicons?sz=128&domain_url=intelimetrica.com',
       role: 'Junior Software Engineer, Data',
       period: '2014 \u2013 2015',
       duration: '1 year',
@@ -86,7 +89,7 @@ export default {
   education: [
     {
       institution: 'Mexico Autonomous Institute of Technology (ITAM)',
-      logoUrl: 'https://logo.clearbit.com/itam.mx',
+      logoUrl: 'https://www.google.com/s2/favicons?sz=128&domain_url=itam.mx',
       institutionUrl: 'https://itam.mx',
       degree: 'M.Sc. in Computer Science. GPA: 9/10',
       period: 'Aug. 2016 \u2013 Dec. 2018',
@@ -94,7 +97,7 @@ export default {
     {
       institution:
         'Monterrey Institute of Technology and Higher Education (ITESM)',
-      logoUrl: 'https://logo.clearbit.com/tec.mx',
+      logoUrl: 'https://www.google.com/s2/favicons?sz=128&domain_url=tec.mx',
       institutionUrl: 'https://tec.mx',
       degree: 'B.S. in Electronic and Computer Engineering. GPA: 92/100',
       period: 'Jan. 2011 \u2013 Dec. 2015',

--- a/src/pages/__tests__/__snapshots__/contact.test.jsx.snap
+++ b/src/pages/__tests__/__snapshots__/contact.test.jsx.snap
@@ -155,15 +155,16 @@ exports[`Contact page matches snapshot 1`] = `
                   <a
                     class="jsx-2023000637 link  "
                     href="https://airbnb.com"
+                    style="flex-shrink: 0; margin-right: 10px;"
                   >
                     <img
                       alt="Airbnb"
-                      src="https://logo.clearbit.com/airbnb.com"
-                      style="height: 60px; width: 60px; object-fit: contain; margin-right: 10px;"
+                      src="https://www.google.com/s2/favicons?sz=128&domain_url=airbnb.com"
+                      style="height: 60px; width: 60px; max-width: 100%; object-fit: contain;"
                     />
                   </a>
                   <div
-                    style="text-align: left;"
+                    style="text-align: left; flex: 1 1 220px; min-width: 0;"
                   >
                     <h5
                       class="jsx-1136534845 "
@@ -240,15 +241,16 @@ exports[`Contact page matches snapshot 1`] = `
                   <a
                     class="jsx-2023000637 link  "
                     href="https://carta.com"
+                    style="flex-shrink: 0; margin-right: 10px;"
                   >
                     <img
                       alt="Carta"
-                      src="https://logo.clearbit.com/carta.com"
-                      style="height: 60px; width: 60px; object-fit: contain; margin-right: 10px;"
+                      src="/carta-logo-blue.svg"
+                      style="height: 60px; width: 60px; max-width: 100%; object-fit: contain;"
                     />
                   </a>
                   <div
-                    style="text-align: left;"
+                    style="text-align: left; flex: 1 1 220px; min-width: 0;"
                   >
                     <h5
                       class="jsx-1136534845 "
@@ -311,15 +313,16 @@ exports[`Contact page matches snapshot 1`] = `
                   <a
                     class="jsx-2023000637 link  "
                     href="https://wizeline.com"
+                    style="flex-shrink: 0; margin-right: 10px;"
                   >
                     <img
                       alt="Wizeline"
                       src="https://www.wizeline.ai/wp-content/uploads/2025/02/wozelinered.svg"
-                      style="height: 60px; width: 60px; object-fit: contain; margin-right: 10px;"
+                      style="height: 60px; width: 60px; max-width: 100%; object-fit: contain;"
                     />
                   </a>
                   <div
-                    style="text-align: left;"
+                    style="text-align: left; flex: 1 1 220px; min-width: 0;"
                   >
                     <h5
                       class="jsx-1136534845 "
@@ -382,15 +385,16 @@ exports[`Contact page matches snapshot 1`] = `
                   <a
                     class="jsx-2023000637 link  "
                     href="https://rappi.com"
+                    style="flex-shrink: 0; margin-right: 10px;"
                   >
                     <img
                       alt="Rappi"
-                      src="https://logo.clearbit.com/rappi.com"
-                      style="height: 60px; width: 60px; object-fit: contain; margin-right: 10px;"
+                      src="https://www.google.com/s2/favicons?sz=128&domain_url=rappi.com"
+                      style="height: 60px; width: 60px; max-width: 100%; object-fit: contain;"
                     />
                   </a>
                   <div
-                    style="text-align: left;"
+                    style="text-align: left; flex: 1 1 220px; min-width: 0;"
                   >
                     <h5
                       class="jsx-1136534845 "
@@ -446,15 +450,16 @@ exports[`Contact page matches snapshot 1`] = `
                   <a
                     class="jsx-2023000637 link  "
                     href="https://sertech.com"
+                    style="flex-shrink: 0; margin-right: 10px;"
                   >
                     <img
                       alt="Sertech Consulting Group"
-                      src="https://logo.clearbit.com/sertech.com"
-                      style="height: 60px; width: 60px; object-fit: contain; margin-right: 10px;"
+                      src="https://sertech.mx/wp-content/themes/sertech/assets/assets_home/img/logo_header.png"
+                      style="height: 60px; width: 60px; max-width: 100%; object-fit: contain;"
                     />
                   </a>
                   <div
-                    style="text-align: left;"
+                    style="text-align: left; flex: 1 1 220px; min-width: 0;"
                   >
                     <h5
                       class="jsx-1136534845 "
@@ -510,15 +515,16 @@ exports[`Contact page matches snapshot 1`] = `
                   <a
                     class="jsx-2023000637 link  "
                     href="https://intelimetrica.com"
+                    style="flex-shrink: 0; margin-right: 10px;"
                   >
                     <img
                       alt="Intelimetrica"
-                      src="https://logo.clearbit.com/intelimetrica.com"
-                      style="height: 60px; width: 60px; object-fit: contain; margin-right: 10px;"
+                      src="https://www.google.com/s2/favicons?sz=128&domain_url=intelimetrica.com"
+                      style="height: 60px; width: 60px; max-width: 100%; object-fit: contain;"
                     />
                   </a>
                   <div
-                    style="text-align: left;"
+                    style="text-align: left; flex: 1 1 220px; min-width: 0;"
                   >
                     <h5
                       class="jsx-1136534845 "
@@ -587,15 +593,16 @@ exports[`Contact page matches snapshot 1`] = `
                   <a
                     class="jsx-2023000637 link  "
                     href="https://itam.mx"
+                    style="flex-shrink: 0; margin-right: 10px;"
                   >
                     <img
                       alt="Mexico Autonomous Institute of Technology (ITAM)"
-                      src="https://logo.clearbit.com/itam.mx"
-                      style="height: 60px; width: 60px; object-fit: contain; margin-right: 10px;"
+                      src="https://www.google.com/s2/favicons?sz=128&domain_url=itam.mx"
+                      style="height: 60px; width: 60px; max-width: 100%; object-fit: contain;"
                     />
                   </a>
                   <div
-                    style="text-align: left;"
+                    style="text-align: left; flex: 1 1 220px; min-width: 0;"
                   >
                     <h5
                       class="jsx-1136534845 "
@@ -627,15 +634,16 @@ exports[`Contact page matches snapshot 1`] = `
                   <a
                     class="jsx-2023000637 link  "
                     href="https://tec.mx"
+                    style="flex-shrink: 0; margin-right: 10px;"
                   >
                     <img
                       alt="Monterrey Institute of Technology and Higher Education (ITESM)"
-                      src="https://logo.clearbit.com/tec.mx"
-                      style="height: 60px; width: 60px; object-fit: contain; margin-right: 10px;"
+                      src="https://www.google.com/s2/favicons?sz=128&domain_url=tec.mx"
+                      style="height: 60px; width: 60px; max-width: 100%; object-fit: contain;"
                     />
                   </a>
                   <div
-                    style="text-align: left;"
+                    style="text-align: left; flex: 1 1 220px; min-width: 0;"
                   >
                     <h5
                       class="jsx-1136534845 "

--- a/src/pages/contact.jsx
+++ b/src/pages/contact.jsx
@@ -126,20 +126,34 @@ const Contact = ({ switchTheme }) => {
                   shadow
                   style={{ marginBottom: '15px', padding: '10px' }}
                 >
-                  <Row middle="xs" start="xs">
-                    <Link href={exp.companyUrl} pure>
+                  <Row
+                    middle="xs"
+                    start="xs"
+                    style={{ flexWrap: 'wrap', rowGap: '10px' }}
+                  >
+                    <Link
+                      href={exp.companyUrl}
+                      pure
+                      style={{ flexShrink: 0, marginRight: '10px' }}
+                    >
                       <img
                         alt={exp.company}
                         src={exp.logoUrl}
                         style={{
                           height: '60px',
                           width: '60px',
+                          maxWidth: '100%',
                           objectFit: 'contain',
-                          marginRight: '10px',
                         }}
                       />
                     </Link>
-                    <div style={{ textAlign: 'left' }}>
+                    <div
+                      style={{
+                        textAlign: 'left',
+                        flex: '1 1 220px',
+                        minWidth: 0,
+                      }}
+                    >
                       <Text h5 style={{ marginBottom: '5px' }}>
                         {exp.role}
                       </Text>
@@ -184,22 +198,36 @@ const Contact = ({ switchTheme }) => {
                   shadow
                   style={{ marginBottom: '15px', padding: '10px' }}
                 >
-                  <Row middle="xs" start="xs">
+                  <Row
+                    middle="xs"
+                    start="xs"
+                    style={{ flexWrap: 'wrap', rowGap: '10px' }}
+                  >
                     {ed.logoUrl && (
-                      <Link href={ed.institutionUrl} pure>
+                      <Link
+                        href={ed.institutionUrl}
+                        pure
+                        style={{ flexShrink: 0, marginRight: '10px' }}
+                      >
                         <img
                           alt={ed.institution}
                           src={ed.logoUrl}
                           style={{
                             height: '60px',
                             width: '60px',
+                            maxWidth: '100%',
                             objectFit: 'contain',
-                            marginRight: '10px',
                           }}
                         />
                       </Link>
                     )}
-                    <div style={{ textAlign: 'left' }}>
+                    <div
+                      style={{
+                        textAlign: 'left',
+                        flex: '1 1 220px',
+                        minWidth: 0,
+                      }}
+                    >
                       <Text h5>{ed.institution}</Text>
                       <Text small>{ed.degree}</Text>
                       <Text small>{ed.period}</Text>

--- a/static/carta-logo-blue.svg
+++ b/static/carta-logo-blue.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 120" role="img" aria-label="Carta logo">
+  <rect x="6" y="6" width="108" height="108" rx="24" fill="#2F6FED"/>
+  <path d="M60 34c17 0 31 12 35 28H80c-3-7-11-12-20-12-12 0-22 10-22 22s10 22 22 22c9 0 17-5 20-12h15c-4 16-18 28-35 28-21 0-38-17-38-38s17-38 38-38z" fill="#FFFFFF"/>
+  <text x="132" y="78" font-family="Arial, Helvetica, sans-serif" font-size="44" font-weight="700" fill="#2F6FED">carta</text>
+</svg>


### PR DESCRIPTION
### Motivation
- Ensure the Carta logo is visible on the Contact page by restoring a local blue SVG wordmark and avoid the previous tiny/fallback favicon rendering. 
- Use the Sertech website's official header logo as requested to better match branding. 
- Fix layout overflow on small screens where company/education logo + text rows could wrap incorrectly and cause visual overflow.

### Description
- Replaced Carta's remote favicon with a local SVG at `static/carta-logo-blue.svg` and updated `logoUrl` for Carta in `src/constants/resume.js` to point to `/carta-logo-blue.svg`.
- Updated Sertech's `logoUrl` in `src/constants/resume.js` to use `https://sertech.mx/.../logo_header.png` as requested and standardized several other logo entries to use Google favicon endpoints for consistent small-image fallbacks.
- Modified `src/pages/contact.jsx` to make experience and education rows responsive by adding `style={{ flexWrap: 'wrap', rowGap: '10px' }}` on the `Row`, preventing logo shrinkage with `style={{ flexShrink: 0, marginRight: '10px' }}` on the logo `Link`, constraining images with `maxWidth: '100%'`, and making the text block flexible with `flex: '1 1 220px'` and `minWidth: 0` to avoid overflow.
- Updated the contact page snapshot at `src/pages/__tests__/__snapshots__/contact.test.jsx.snap` to reflect the new image sources and layout.

### Testing
- Ran `yarn install` which completed successfully with non-blocking warnings about peer deps and baseline data.
- Ran `yarn format` and formatting completed successfully.
- Ran `yarn test` which initially failed due to an expected snapshot mismatch, then ran `yarn test -u` to update snapshots and re-ran `yarn test`, after which all test suites passed.
- Ran `yarn build` and the production build completed successfully.
- Ran `yarn develop` and verified the dev server started (reviewed existing Geist/Gatsby and baseline warnings as non-blocking) and captured an updated mobile screenshot of `/contact` to validate the responsive layout and logos.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998d074e0a0832f927ce41a91a03a80)